### PR TITLE
chore(menu): tenant-agnostic naan helpers

### DIFF
--- a/src/api/engine/dispatcher_engine.py
+++ b/src/api/engine/dispatcher_engine.py
@@ -1,18 +1,60 @@
 from .types import ResponsePlan, PlanAction
 
+
 class DispatcherEngine:
     def plan(self, state, transcript: str) -> ResponsePlan:
+        lang = getattr(state, "lang", "en") or "en"
         t = (transcript or "").strip()
+        t_norm = t.lower()
 
-        # First message (no user input yet) => greeting owned here
+        # ---- Connect-tick greeting (one-time) ----
         if not t:
-            lang = getattr(state, "lang", "en")
+            if getattr(state, "dispatcher_greeted", False):
+                return ResponsePlan(action=PlanAction.NOOP, reply="", lang=lang)
+
+            setattr(state, "dispatcher_greeted", True)
+
             greet = (
-                "Hi, this is Voxeron. Which service do you need?"
+                "Hi, thank you for calling Vox8. Which service do you need?"
                 if lang != "nl"
-                else "Hoi, u spreekt met Voxeron. Met welke dienst kan ik u helpen?"
+                else "Hoi, u spreekt met Vox Eight. Met welke dienst kan ik u helpen?"
             )
             return ResponsePlan(action=PlanAction.REPLY, reply=greet, lang=lang)
 
-        # ... existing routing rules (Indian food -> hotswap tenant, etc.)
-        return ResponsePlan(action=PlanAction.NOOP, reply="", lang=getattr(state, "lang", "en"))
+        # ---- Routing signals ----
+        turkish = ["tesisat", "tesisatçı", "tamir", "sızınt", "boru", "su bas", "gaz kok"]
+        plumber_nl = ["loodgieter", "lekkage", "spoed", "water", "leiding", "verstopping", "afvoer"]
+        plumber_en = ["plumber", "leak", "burst", "pipe", "flood", "repair", "emergency"]
+
+        food_nl = ["eten", "bestellen", "indiaas", "restaurant", "afhalen", "bezorgen"]
+        food_en = ["food", "hungry", "order", "restaurant", "indian"]
+
+        connect_reply = "Okay — connecting you now." if lang != "nl" else "Prima — ik verbind u nu door."
+
+        if (
+            any(k in t_norm for k in turkish)
+            or any(k in t_norm for k in plumber_nl)
+            or any(k in t_norm for k in plumber_en)
+        ):
+            return ResponsePlan(
+                action=PlanAction.HOTSWAP_TENANT,
+                reply=connect_reply,
+                lang=lang,
+                hotswap_tenant_ref="abt",
+            )
+
+        if any(k in t_norm for k in food_nl) or any(k in t_norm for k in food_en):
+            return ResponsePlan(
+                action=PlanAction.HOTSWAP_TENANT,
+                reply=connect_reply,
+                lang=lang,
+                hotswap_tenant_ref="taj_mahal",
+            )
+
+        # ---- No match: ask again ----
+        ask = (
+            "Which service do you need, restaurant ordering or an emergency plumber?"
+            if lang != "nl"
+            else "Welke dienst heeft u nodig, eten bestellen of een spoed loodgieter?"
+        )
+        return ResponsePlan(action=PlanAction.CLARIFY, reply=ask, lang=lang)

--- a/src/api/engine/dispatcher_engine.py
+++ b/src/api/engine/dispatcher_engine.py
@@ -1,0 +1,18 @@
+from .types import ResponsePlan, PlanAction
+
+class DispatcherEngine:
+    def plan(self, state, transcript: str) -> ResponsePlan:
+        t = (transcript or "").strip()
+
+        # First message (no user input yet) => greeting owned here
+        if not t:
+            lang = getattr(state, "lang", "en")
+            greet = (
+                "Hi, this is Voxeron. Which service do you need?"
+                if lang != "nl"
+                else "Hoi, u spreekt met Voxeron. Met welke dienst kan ik u helpen?"
+            )
+            return ResponsePlan(action=PlanAction.REPLY, reply=greet, lang=lang)
+
+        # ... existing routing rules (Indian food -> hotswap tenant, etc.)
+        return ResponsePlan(action=PlanAction.NOOP, reply="", lang=getattr(state, "lang", "en"))

--- a/src/api/engine/restaurant_engine.py
+++ b/src/api/engine/restaurant_engine.py
@@ -1,6 +1,7 @@
+# src/api/engine/restaurant_engine.py
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any, List, Optional
 
 from .types import PlanAction, ResponsePlan
 from ..intent import norm_simple
@@ -29,53 +30,162 @@ class RestaurantEngine:
         menu = getattr(state, "menu", None)
         if not menu:
             return ranked
-
         available = {menu.display_name(iid) for _n, iid in getattr(menu, "name_choices", [])}
         return [x for x in ranked if x in available] or ranked
 
-    def plan(self, state: Any, transcript: str) -> ResponsePlan:
-        st = state
-        tnorm = norm_simple(transcript)
+    def _find_naan_item_id(self, menu: Any, variant: str) -> Optional[str]:
+        """
+        Deterministic lookup based on display name only.
+        Avoids imports into infrastructure modules.
+        """
+        v = (variant or "").lower().strip()
+        choices = getattr(menu, "name_choices", []) or []
 
-        # 1) Pending naan variant: answer spicy question + reprompt
-        if getattr(st, "pending_choice", None) == "nan_variant" and getattr(st, "menu", None):
-            if self._is_spicy_query(transcript) or self._looks_like_question(transcript):
-                if st.lang == "nl":
-                    info = (
-                        "Naans zijn meestal niet pittig, het is brood om pittige curry te balanceren. "
-                        "Keema naan kan wat kruidiger zijn, peshawari is juist wat zoeter."
-                    )
-                else:
-                    info = (
-                        "Naans are usually not spicy — they’re bread to balance spicy curries. "
-                        "Keema naan can be a bit more spiced, and peshawari is sweet."
-                    )
+        # Collect candidate display names once
+        items: List[tuple[str, str]] = []
+        for _n, iid in choices:
+            dn = (menu.display_name(iid) or "").strip()
+            if not dn:
+                continue
+            items.append((iid, dn.lower()))
 
+        if v == "keema":
+            for iid, dn in items:
+                if "naan" in dn and "keema" in dn:
+                    return iid
+            # fallback: some menus spell "kheema"
+            for iid, dn in items:
+                if "naan" in dn and "kheema" in dn:
+                    return iid
+            return None
+
+        # plain/default
+        for iid, dn in items:
+            if "naan" not in dn:
+                continue
+            # exclude flavored variants if possible
+            if any(x in dn for x in ("keema", "kheema", "garlic", "peshawari", "cheese", "chili", "stuffed")):
+                continue
+            return iid
+
+        # fallback: any naan item
+        for iid, dn in items:
+            if "naan" in dn:
+                return iid
+        return None
+
+    def _resolve_pending_nan_variant(self, st: Any, transcript: str) -> ResponsePlan | None:
+        if getattr(st, "pending_choice", None) != "nan_variant":
+            return None
+
+        lang = getattr(st, "lang", "en")
+        menu = getattr(st, "menu", None)
+
+        tnorm = norm_simple(transcript) or ""
+        t = f" {tnorm} "
+
+        is_keema = any(x in t for x in (" keema ", " kheema "))
+        is_plain = any(x in t for x in (
+            " none ", " plain ", " regular ", " normal ",
+            " gewoon ", " normaal ", " standaard ",
+            " naan ", " nan ",
+            " nee ", " nee hoor ",
+        ))
+        is_cancel = any(x in t for x in (
+            " cancel ", " stop ", " nothing ", " niks ", " niets ",
+            " dat is alles ", " dat was alles ", " klaar ",
+            " no thanks ", " no thank you ",
+        ))
+
+        # If user is asking a question, keep the clarification loop
+        if self._is_spicy_query(transcript) or self._looks_like_question(transcript):
+            if lang == "nl":
+                info = (
+                    "Naans zijn meestal niet pittig, het is brood om pittige curry te balanceren. "
+                    "Keema naan kan wat kruidiger zijn, peshawari is juist wat zoeter."
+                )
+            else:
+                info = (
+                    "Naans are usually not spicy — they’re bread to balance spicy curries. "
+                    "Keema naan can be a bit more spiced, and peshawari is sweet."
+                )
+            return ResponsePlan(
+                action=PlanAction.CLARIFY,
+                reply=f"{info} {nan_variant_question(lang, verbose=False)}",
+                lang=lang,
+                pending_choice="nan_variant",
+                pending_qty=max(1, int(getattr(st, "pending_qty", 1) or 1)),
+                debug={"reason": "naan_spicy_question_override"},
+            )
+
+        # If user is answering the choice (or canceling it), resolve deterministically
+        if is_cancel:
+            st.pending_choice = None
+            return ResponsePlan(
+                action=PlanAction.UPDATE_CART,
+                reply="",
+                lang=lang,
+                pending_choice=None,
+                pending_qty=max(1, int(getattr(st, "pending_qty", 1) or 1)),
+                debug={"reason": "naan_variant_cancelled"},
+            )
+
+        if is_keema or is_plain:
+            if not menu:
+                # No menu loaded => just clear the gate and continue.
+                st.pending_choice = None
                 return ResponsePlan(
-                    action=PlanAction.CLARIFY,
-                    reply=f"{info} {nan_variant_question(st.lang, verbose=False)}",
-                    lang=st.lang,
-                    pending_choice="nan_variant",
-                    pending_qty=getattr(st, "pending_qty", 1),
-                    debug={"reason": "naan_spicy_question_override"},
+                    action=PlanAction.NOOP,
+                    reply="",
+                    lang=lang,
+                    pending_choice=None,
+                    pending_qty=max(1, int(getattr(st, "pending_qty", 1) or 1)),
+                    debug={"reason": "naan_variant_cleared_no_menu"},
                 )
 
-        # 2) “What lamb dishes…” → crisp top-3 + ask preference
+            variant = "keema" if is_keema else "plain"
+            iid = self._find_naan_item_id(menu, variant)
+            qty = max(1, int(getattr(st, "pending_qty", 1) or 1))
+
+            if iid:
+                st.order.add(iid, qty)
+
+            st.pending_choice = None
+            return ResponsePlan(
+                action=PlanAction.UPDATE_CART,
+                reply="",
+                lang=lang,
+                pending_choice=None,
+                pending_qty=qty,
+                debug={"reason": "naan_variant_resolved", "variant": variant, "added": bool(iid)},
+            )
+
+        # Not understood => let controller continue (it may ask pickup/delivery etc.)
+        return None
+
+    def plan(self, state: Any, transcript: str) -> ResponsePlan:
+        st = state
+
+        # 0) Resolve pending choice FIRST
+        resolved = self._resolve_pending_nan_variant(st, transcript)
+        if resolved is not None:
+            return resolved
+
+        tnorm = norm_simple(transcript)
+
+        # 1) “What lamb dishes…” → crisp top-3 + ask preference
         if tnorm and "lamb" in tnorm and "menu" in tnorm and any(x in tnorm for x in ("dish", "dishes", "gerechten")):
             top3 = self._top3_lamb(st)
             items = ", ".join(top3)
-
-            if st.lang == "nl":
+            if getattr(st, "lang", "en") == "nl":
                 msg = f"Even kijken. We hebben bijvoorbeeld {items}. Zegt een van deze u iets?"
             else:
                 msg = (
                     f"Let me check the menu for you. We have a few great lamb dishes like {items}. "
                     "Do any of those sound good?"
                 )
-
             st.last_category = "lamb"
             st.last_category_items = top3
-            return ResponsePlan(action=PlanAction.REPLY, reply=msg, lang=st.lang, debug={"reason": "top3_lamb"})
+            return ResponsePlan(action=PlanAction.REPLY, reply=msg, lang=getattr(st, "lang", "en"), debug={"reason": "top3_lamb"})
 
-        # Default: let existing controller continue (for now)
         return ResponsePlan(action=PlanAction.NOOP, reply="", lang=getattr(st, "lang", "en"))

--- a/src/api/engine/restaurant_engine.py
+++ b/src/api/engine/restaurant_engine.py
@@ -1,30 +1,35 @@
 from __future__ import annotations
+
 from typing import Any, List
-from .types import ResponsePlan, PlanAction
+
+from .types import PlanAction, ResponsePlan
 from ..intent import norm_simple
 from ..policy import nan_variant_question
 
+
 class RestaurantEngine:
+    _Q_WORDS = ("which", "what", "welke", "wat", "hoe", "variety", "soorten", "wat voor")
+    _SPICY_WORDS = ("spicy", "very spicy", "hot", "heet", "pittig", "heel pittig")
+
     def _looks_like_question(self, text: str) -> bool:
         raw = (text or "").strip()
-        tn = norm_simple(raw)
-        if not tn:
+        if not raw:
             return False
         if "?" in raw:
             return True
-        return any(w in tn for w in ["which", "what", "welke", "wat", "hoe", "variety", "soorten", "wat voor"])
+        tn = norm_simple(raw)
+        return bool(tn) and any(w in tn for w in self._Q_WORDS)
 
     def _is_spicy_query(self, text: str) -> bool:
         t = norm_simple(text)
-        return any(x in t for x in ["spicy", "very spicy", "hot", "heet", "pittig", "heel pittig"])
+        return bool(t) and any(x in t for x in self._SPICY_WORDS)
 
     def _top3_lamb(self, state: Any) -> List[str]:
-        # tenant-config later; simple default for now
         ranked = ["Lamb Dhansak", "Lamb Biryani", "Lamb Korma"]
-        # Only keep items that exist in menu, if menu is available
         menu = getattr(state, "menu", None)
         if not menu:
             return ranked
+
         available = {menu.display_name(iid) for _n, iid in getattr(menu, "name_choices", [])}
         return [x for x in ranked if x in available] or ranked
 
@@ -36,11 +41,16 @@ class RestaurantEngine:
         if getattr(st, "pending_choice", None) == "nan_variant" and getattr(st, "menu", None):
             if self._is_spicy_query(transcript) or self._looks_like_question(transcript):
                 if st.lang == "nl":
-                    info = ("Naans zijn meestal niet pittig, het is brood om pittige curry te balanceren. "
-                            "Keema naan kan wat kruidiger zijn, peshawari is juist wat zoeter.")
+                    info = (
+                        "Naans zijn meestal niet pittig, het is brood om pittige curry te balanceren. "
+                        "Keema naan kan wat kruidiger zijn, peshawari is juist wat zoeter."
+                    )
                 else:
-                    info = ("Naans are usually not spicy — they’re bread to balance spicy curries. "
-                            "Keema naan can be a bit more spiced, and peshawari is sweet.")
+                    info = (
+                        "Naans are usually not spicy — they’re bread to balance spicy curries. "
+                        "Keema naan can be a bit more spiced, and peshawari is sweet."
+                    )
+
                 return ResponsePlan(
                     action=PlanAction.CLARIFY,
                     reply=f"{info} {nan_variant_question(st.lang, verbose=False)}",
@@ -51,18 +61,21 @@ class RestaurantEngine:
                 )
 
         # 2) “What lamb dishes…” → crisp top-3 + ask preference
-        if "lamb" in tnorm and "menu" in tnorm and ("dish" in tnorm or "dishes" in tnorm or "gerechten" in tnorm):
+        if tnorm and "lamb" in tnorm and "menu" in tnorm and any(x in tnorm for x in ("dish", "dishes", "gerechten")):
             top3 = self._top3_lamb(st)
             items = ", ".join(top3)
+
             if st.lang == "nl":
                 msg = f"Even kijken. We hebben bijvoorbeeld {items}. Zegt een van deze u iets?"
             else:
-                msg = f"Let me check the menu for you. We have a few great lamb dishes like {items}. Do any of those sound good?"
-            # store stickiness
+                msg = (
+                    f"Let me check the menu for you. We have a few great lamb dishes like {items}. "
+                    "Do any of those sound good?"
+                )
+
             st.last_category = "lamb"
             st.last_category_items = top3
             return ResponsePlan(action=PlanAction.REPLY, reply=msg, lang=st.lang, debug={"reason": "top3_lamb"})
 
         # Default: let existing controller continue (for now)
         return ResponsePlan(action=PlanAction.NOOP, reply="", lang=getattr(st, "lang", "en"))
-

--- a/src/api/engine/restaurant_engine.py
+++ b/src/api/engine/restaurant_engine.py
@@ -160,11 +160,35 @@ class RestaurantEngine:
                 debug={"reason": "naan_variant_resolved", "variant": variant, "added": bool(iid)},
             )
 
-        # Not understood => let controller continue (it may ask pickup/delivery etc.)
-        return None
+        # Not understood => keep gate and let controller continue
+        return ResponsePlan(
+            action=PlanAction.NOOP,
+            reply="",
+            lang=getattr(st, "lang", "en"),
+            pending_choice="nan_variant",
+            pending_qty=max(1, int(getattr(st, "pending_qty", 1) or 1)),
+            debug={"reason": "naan_variant_not_understood"},
+        )
 
     def plan(self, state: Any, transcript: str) -> ResponsePlan:
         st = state
+
+        t_raw = (transcript or "").strip()
+        lang = getattr(st, "lang", "en") or "en"
+
+        # Connect-tick greeting (one-time) for restaurant domain
+        if not t_raw:
+            if getattr(st, "restaurant_greeted", False):
+                return ResponsePlan(action=PlanAction.NOOP, reply="", lang=lang)
+
+            setattr(st, "restaurant_greeted", True)
+
+            greet = (
+                "Hi! Welcome to Taj Mahal Bussum. You can start ordering now. If you want Dutch, say 'Nederlands'."
+                if lang != "nl"
+                else "Welkom bij Taj Mahal Bussum. Je kunt nu bestellen."
+            )
+            return ResponsePlan(action=PlanAction.REPLY, reply=greet, lang=lang)
 
         # 0) Resolve pending choice FIRST
         resolved = self._resolve_pending_nan_variant(st, transcript)
@@ -177,7 +201,7 @@ class RestaurantEngine:
         if tnorm and "lamb" in tnorm and "menu" in tnorm and any(x in tnorm for x in ("dish", "dishes", "gerechten")):
             top3 = self._top3_lamb(st)
             items = ", ".join(top3)
-            if getattr(st, "lang", "en") == "nl":
+            if lang == "nl":
                 msg = f"Even kijken. We hebben bijvoorbeeld {items}. Zegt een van deze u iets?"
             else:
                 msg = (
@@ -186,6 +210,19 @@ class RestaurantEngine:
                 )
             st.last_category = "lamb"
             st.last_category_items = top3
-            return ResponsePlan(action=PlanAction.REPLY, reply=msg, lang=getattr(st, "lang", "en"), debug={"reason": "top3_lamb"})
+            return ResponsePlan(
+                action=PlanAction.REPLY,
+                reply=msg,
+                lang=lang,
+                debug={"reason": "top3_lamb"},
+            )
 
-        return ResponsePlan(action=PlanAction.NOOP, reply="", lang=getattr(st, "lang", "en"))
+        # Default: do nothing, let SessionController continue with deterministic ordering logic
+        return ResponsePlan(
+            action=PlanAction.NOOP,
+            reply="",
+            lang=lang,
+            debug={"reason": "restaurant_noop_default"},
+        )
+
+

--- a/src/api/engine/router.py
+++ b/src/api/engine/router.py
@@ -7,7 +7,7 @@ from .types import ResponsePlan, PlanAction
 from .restaurant_engine import RestaurantEngine
 from .dispatcher_engine import DispatcherEngine
 
-logger = logging.getLogger("taj-agent")
+logger = logging.getLogger(__name__)
 
 
 class DomainRouter:
@@ -18,18 +18,17 @@ class DomainRouter:
     def plan(self, state: Any, transcript: str) -> ResponsePlan:
         phase = getattr(state, "phase", "") or ""
 
+        # Dispatcher phase: ALWAYS dispatcher
         if phase == "dispatcher":
             p = self.dispatcher.plan(state, transcript)
             if p is None:
                 logger.error("CRITICAL: DispatcherEngine.plan returned None (phase=%s)", phase)
-                return ResponsePlan(action=PlanAction.NOOP, reply="", lang=getattr(state, "lang", "en"))
+                return ResponsePlan(action=PlanAction.NOOP, reply="", lang=getattr(state, "lang", "en") or "en")
             return p
 
+        # Chat phase (default Taj demo): restaurant engine
         p = self.restaurant.plan(state, transcript)
         if p is None:
-            logger.error(
-                "CRITICAL: RestaurantEngine.plan returned None (phase=%s)",
-                phase,
-            )
-            return ResponsePlan(action=PlanAction.NOOP, reply="", lang=getattr(state, "lang", "en"))
+            logger.error("CRITICAL: RestaurantEngine.plan returned None (phase=%s)", phase)
+            return ResponsePlan(action=PlanAction.NOOP, reply="", lang=getattr(state, "lang", "en") or "en")
         return p

--- a/src/api/engine/router.py
+++ b/src/api/engine/router.py
@@ -1,19 +1,35 @@
 from __future__ import annotations
+
+import logging
 from typing import Any
-from .types import ResponsePlan
+
+from .types import ResponsePlan, PlanAction
 from .restaurant_engine import RestaurantEngine
 from .dispatcher_engine import DispatcherEngine
 
+logger = logging.getLogger("taj-agent")
+
+
 class DomainRouter:
-    def __init__(self):
+    def __init__(self) -> None:
         self.dispatcher = DispatcherEngine()
         self.restaurant = RestaurantEngine()
 
     def plan(self, state: Any, transcript: str) -> ResponsePlan:
-        # If we're in dispatcher phase, route there
-        if getattr(state, "phase", "") == "dispatcher":
-            return self.dispatcher.plan(state, transcript)
+        phase = getattr(state, "phase", "") or ""
 
-        # Default (Taj demo): restaurant engine
-        return self.restaurant.plan(state, transcript)
+        if phase == "dispatcher":
+            p = self.dispatcher.plan(state, transcript)
+            if p is None:
+                logger.error("CRITICAL: DispatcherEngine.plan returned None (phase=%s)", phase)
+                return ResponsePlan(action=PlanAction.NOOP, reply="", lang=getattr(state, "lang", "en"))
+            return p
 
+        p = self.restaurant.plan(state, transcript)
+        if p is None:
+            logger.error(
+                "CRITICAL: RestaurantEngine.plan returned None (phase=%s)",
+                phase,
+            )
+            return ResponsePlan(action=PlanAction.NOOP, reply="", lang=getattr(state, "lang", "en"))
+        return p

--- a/src/api/engine/types.py
+++ b/src/api/engine/types.py
@@ -1,15 +1,50 @@
+# src/api/engine/types.py
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+
 class PlanAction(str, Enum):
-    REPLY = "reply"               # speak reply
-    CLARIFY = "clarify"           # ask for missing slot
-    UPDATE_CART = "update_cart"   # deterministic add/remove already applied
+    """What the engine wants the controller to do next."""
+    REPLY = "reply"                 # speak reply
+    CLARIFY = "clarify"             # ask for missing slot / choice
+    UPDATE_CART = "update_cart"     # cart mutation already applied deterministically
     HOTSWAP_TENANT = "hotswap_tenant"
-    NOOP = "noop"                 # do nothing (e.g., incomplete utterance)
+    NOOP = "noop"                   # do nothing (e.g., incomplete utterance)
     END_CALL = "end_call"
+
+
+@dataclass(frozen=True)
+class ChoiceResolution:
+    """
+    Generic choice resolution payload.
+
+    The controller must not interpret semantics here.
+    It only forwards this payload to an engine-owned applier (or router),
+    and clears the pending gate.
+    """
+    key: str                        # e.g. "nan_variant" (engine-defined)
+    value: str                      # e.g. "plain" | "keema" | "cancel"
+    qty: int = 1
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CartOp:
+    """
+    Generic cart operation. Controller stays menu-blind.
+
+    op:
+      - "add"     => add qty to item_id
+      - "set_qty" => set qty for item_id (qty<=0 removes)
+    """
+    op: str                         # "add" | "set_qty"
+    item_id: str
+    qty: int = 1
+    meta: Dict[str, Any] = field(default_factory=dict)
+
 
 @dataclass
 class ResponsePlan:
@@ -21,9 +56,14 @@ class ResponsePlan:
     hotswap_tenant_ref: Optional[str] = None
 
     # flow control / slots
-    pending_choice: Optional[str] = None  # e.g. "nan_variant"
+    pending_choice: Optional[str] = None   # engine-defined, e.g. "nan_variant"
     pending_qty: int = 1
+
+    # Generic cart operations (controller stays menu-blind)
+    cart_ops: List[CartOp] = field(default_factory=list)
+
+    # If set, controller should apply via engine/applier and clear pending_choice
+    resolved_choice: Optional[ChoiceResolution] = None
 
     # optional debug metadata
     debug: Dict[str, Any] = field(default_factory=dict)
-

--- a/src/api/menu_knowledge.py
+++ b/src/api/menu_knowledge.py
@@ -245,3 +245,121 @@ def suggest_substitution(
     # Protein-only, no spice preference: avoid overly confident picks
     ranked = sorted(candidates, key=lambda x: (len(x), x))
     return ranked[0], max(0.0, safe_fail_threshold - 0.05), "fallback:protein-only"
+
+# -----------------------------------------------------------------------------
+# Naan helpers (tenant-agnostic, menu-aware)
+# -----------------------------------------------------------------------------
+_NAAN_WORDS: Tuple[str, ...] = ("naan", "nan", "naam")
+
+
+def is_naan_item(menu: MenuSnapshot, item_id: str) -> bool:
+    if not menu or not item_id:
+        return False
+    dn = (menu.display_name(item_id) or "").lower()
+    return any(w in dn for w in _NAAN_WORDS)
+
+
+def naan_options_from_menu(menu: MenuSnapshot) -> List[Tuple[str, str]]:
+    """
+    Return [(label, item_id)] sorted with plain/garlic first when available.
+    """
+    if not menu:
+        return []
+
+    items: List[Tuple[str, str]] = []
+    for _name, iid in menu.name_choices:
+        if not is_naan_item(menu, iid):
+            continue
+        label = (menu.display_name(iid) or "").strip()
+        if label:
+            items.append((label, iid))
+
+    if not items:
+        return []
+
+    prefs: List[Tuple[str, Tuple[str, ...]]] = [
+        ("plain", ("naan", "nan", "plain", "regular", "normal", "gewoon", "normaal", "standaard")),
+        ("garlic", ("garlic", "knoflook")),
+        ("butter", ("butter", "boter")),
+        ("cheese", ("cheese", "kaas")),
+        ("keema", ("keema", "kheema")),
+        ("peshawari", ("peshawari",)),
+    ]
+
+    def score(label: str) -> int:
+        ll = label.lower().strip()
+        if ll in {"nan", "naan"}:
+            return 200
+        for i, (_k, toks) in enumerate(prefs):
+            if any(t in ll for t in toks):
+                return 150 - i
+        return 0
+
+    items.sort(key=lambda x: (score(x[0]), -len(x[0])), reverse=True)
+    return items
+
+
+def naan_optima_prompt(menu: Optional[MenuSnapshot], lang: str, *, list_mode: str = "short", with_main: Optional[str] = None) -> str:
+    """
+    Minimal Optima-style prompt, optionally using real menu labels when available.
+    """
+    lang_n = (lang or "en").lower()
+    max_n = 2 if list_mode == "short" else 4
+
+    opts = naan_options_from_menu(menu) if menu else []
+    labels = [x[0] for x in opts[:max_n]]
+
+    if not labels:
+        if lang_n == "nl":
+            return f"Zeker. Wil je gewone naan of garlic naan?" if not with_main else f"Zeker. Wil je gewone naan of garlic naan bij je {with_main}?"
+        return f"Certainly. Would you like plain naan or garlic naan?" if not with_main else f"Certainly. Would you like plain naan or garlic naan with your {with_main}?"
+
+    if lang_n == "nl":
+        if len(labels) >= 2:
+            return f"Wil je {labels[0]} of {labels[1]}?"
+        return f"We hebben {labels[0]}. Wil je die?"
+    else:
+        if len(labels) >= 2:
+            return f"Would you like {labels[0]} or {labels[1]}?"
+        return f"We have {labels[0]}. Would you like that?"
+
+
+def find_naan_item_for_variant(menu: Optional[MenuSnapshot], variant: str) -> Optional[str]:
+    """
+    Map a variant keyword (plain/garlic/cheese/...) to the best matching naan item_id in the menu.
+    """
+    if not menu or not variant:
+        return None
+
+    v = variant.strip().lower()
+    opts = naan_options_from_menu(menu)
+    if not opts:
+        return None
+
+    variant_tokens = {
+        "plain": ("naan", "nan", "plain", "regular", "normal", "gewoon", "normaal", "standaard"),
+        "garlic": ("garlic", "knoflook"),
+        "butter": ("butter", "boter"),
+        "cheese": ("cheese", "kaas"),
+        "keema": ("keema", "kheema"),
+        "peshawari": ("peshawari",),
+    }
+
+    toks = variant_tokens.get(v, (v,))
+    best_iid: Optional[str] = None
+    best_score = -1
+
+    for label, iid in opts:
+        ll = label.lower().strip()
+        s = 0
+        if v == "plain" and ll in {"nan", "naan"}:
+            s += 50
+        if any(t in ll for t in toks):
+            s += 25
+        if v in ll:
+            s += 8
+        if s > best_score:
+            best_score = s
+            best_iid = iid
+
+    return best_iid if best_score >= 0 else None

--- a/src/api/menu_knowledge.py
+++ b/src/api/menu_knowledge.py
@@ -94,31 +94,51 @@ def _dedup_keep_order(xs: Iterable[str], *, limit: int) -> List[str]:
 # -----------------------------------------------------------------------------
 def extract_naan_variant_keyword_scoped(text: str) -> Optional[str]:
     """
-    Extract a generic variant keyword (garlic/plain/cheese/etc.) from free text.
-    Tenant-agnostic and menu-agnostic: this only detects the variant intent.
+    Extract a generic naan variant keyword (garlic/cheese/butter/keema/peshawari/plain),
+    but ONLY when it appears in a tight window around a naan token.
+    This prevents false positives like: "butter chicken ... and three naan" -> butter.
     """
     t = norm_simple(text)
     if not t:
         return None
 
-    # Highest-signal variants first
-    if ("garlic" in t) or ("knoflook" in t):
-        return "garlic"
-    if ("cheese" in t) or ("kaas" in t):
-        return "cheese"
-    if ("butter" in t) or ("boter" in t):
-        return "butter"
-    if ("keema" in t) or ("kheema" in t):
-        return "keema"
-    if "peshawari" in t:
-        return "peshawari"
+    toks = [x for x in t.split() if x]
+    if not toks:
+        return None
 
-    # Default/plain signals (keep broad)
-    if any(x in t for x in ("plain", "regular", "normal", "gewoon", "normaal", "standaard")):
-        return "plain"
+    naan_toks = {"naan", "nan"}
+
+    # Variants (highest-signal first)
+    variant_map = [
+        ("garlic", {"garlic", "knoflook"}),
+        ("cheese", {"cheese", "kaas"}),
+        ("butter", {"butter", "boter"}),
+        ("keema", {"keema", "kheema"}),
+        ("peshawari", {"peshawari"}),
+        ("plain", {"plain", "regular", "normal", "gewoon", "normaal", "standaard"}),
+    ]
+
+    naan_positions = [i for i, tok in enumerate(toks) if tok in naan_toks]
+    if not naan_positions:
+        return None
+
+    # Tight context window around naan to avoid "butter chicken ... naan" bleed.
+    WIN_BEFORE = 2
+    WIN_AFTER = 2
+
+    for ni in naan_positions:
+        lo = max(0, ni - WIN_BEFORE)
+        hi = min(len(toks), ni + WIN_AFTER + 1)
+        window = toks[lo:hi]
+
+        for variant, vset in variant_map:
+            if any(w in vset for w in window):
+                # "plain" isn't an explicit variant in most flows; treat as None.
+                if variant == "plain":
+                    return None
+                return variant
 
     return None
-
 
 
 def list_items_for_protein(

--- a/src/api/menu_knowledge.py
+++ b/src/api/menu_knowledge.py
@@ -1,85 +1,165 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 from .intent import norm_simple
 from .menu_store import MenuSnapshot
 
 
-@dataclass
+# -----------------------------------------------------------------------------
+# NOTE (architecture)
+# -----------------------------------------------------------------------------
+# This module is the right place for *menu semantics* and lightweight heuristics.
+# Keep it tenant-agnostic:
+# - No tenant names, no dish-specific business logic tied to a single restaurant.
+# - Use generic "traits" (protein category, spice preference) + menu scanning.
+#
+# If you later add structured metadata to MenuSnapshot (tags/attributes),
+# this file can prefer metadata and fall back to heuristics safely.
+# -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
 class TraitQuery:
-    protein: Optional[str] = None  # lamb/chicken/vegetarian/biryani
+    """
+    Parsed high-level intent, used for suggestion or follow-up prompts.
+
+    protein:
+      A coarse category (e.g., "lamb", "chicken", "vegetarian") that can be mapped
+      to menu attributes or heuristic matches.
+    wants_spicy:
+      Whether user preference implies spicy/hot.
+    raw:
+      Normalized user text used for debugging/tracing.
+    """
+    protein: Optional[str] = None
     wants_spicy: bool = False
     raw: str = ""
 
 
-_SPICY_WORDS = {
+# Keep lists short and generic. Avoid tenant-specific dish names.
+_SPICY_MARKERS: Tuple[str, ...] = (
     "spicy", "hot", "very spicy", "extra spicy",
     "heet", "pittig", "heel heet", "erg pittig",
-    # dish-style hints that often imply heat
-    "madras", "vindaloo", "phall",
-}
+)
 
-_PROTEIN_HINTS = {
-    "lamb": {"lamb", "lam", "lams"},
-    "chicken": {"chicken", "kip"},
-    "vegetarian": {"vegetarian", "vega", "veg", "vegetarisch", "paneer"},
-    "biryani": {"biryani"},
+# "Styles" that often imply heat. Still reasonably generic across Indian menus.
+_SPICY_STYLE_MARKERS: Tuple[str, ...] = (
+    "madras", "vindaloo", "phall",
+)
+
+# Protein categories and their text markers.
+# Keep these broad; don't hard-code specific menu item names.
+_PROTEIN_MARKERS = {
+    "lamb": ("lamb", "lam", "lams"),
+    "chicken": ("chicken", "kip"),
+    "vegetarian": ("vegetarian", "vegetarisch", "vega", "veg", "paneer"),
 }
 
 
 def extract_traits(text: str) -> TraitQuery:
     t = norm_simple(text)
-    q = TraitQuery(raw=t)
+    if not t:
+        return TraitQuery(raw="")
 
-    if any(w in t for w in _SPICY_WORDS):
-        q.wants_spicy = True
+    wants_spicy = any(w in t for w in _SPICY_MARKERS) or any(w in t for w in _SPICY_STYLE_MARKERS)
 
-    for protein, keys in _PROTEIN_HINTS.items():
-        if any(k in t for k in keys):
-            q.protein = protein
+    protein: Optional[str] = None
+    for key, markers in _PROTEIN_MARKERS.items():
+        if any(m in t for m in markers):
+            protein = key
             break
 
-    return q
+    return TraitQuery(protein=protein, wants_spicy=wants_spicy, raw=t)
 
 
-def list_items_for_protein(menu: MenuSnapshot, protein: str) -> List[str]:
-    """
-    MVP fallback: name heuristics (used if metadata isn't available).
-    """
+def _dedup_keep_order(xs: Iterable[str], *, limit: int) -> List[str]:
+    seen = set()
     out: List[str] = []
+    for x in xs:
+        if not x:
+            continue
+        if x in seen:
+            continue
+        seen.add(x)
+        out.append(x)
+        if len(out) >= limit:
+            break
+    return out
+
+# -----------------------------------------------------------------------------
+# Generic variant extraction (tenant-agnostic)
+# -----------------------------------------------------------------------------
+def extract_naan_variant_keyword_scoped(text: str) -> Optional[str]:
+    """
+    Extract a generic variant keyword (garlic/plain/cheese/etc.) from free text.
+    Tenant-agnostic and menu-agnostic: this only detects the variant intent.
+    """
+    t = norm_simple(text)
+    if not t:
+        return None
+
+    # Highest-signal variants first
+    if ("garlic" in t) or ("knoflook" in t):
+        return "garlic"
+    if ("cheese" in t) or ("kaas" in t):
+        return "cheese"
+    if ("butter" in t) or ("boter" in t):
+        return "butter"
+    if ("keema" in t) or ("kheema" in t):
+        return "keema"
+    if "peshawari" in t:
+        return "peshawari"
+
+    # Default/plain signals (keep broad)
+    if any(x in t for x in ("plain", "regular", "normal", "gewoon", "normaal", "standaard")):
+        return "plain"
+
+    return None
+
+
+
+def list_items_for_protein(
+    menu: MenuSnapshot,
+    protein: str,
+    *,
+    limit: int = 80,
+) -> List[str]:
+    """
+    Heuristic fallback if menu metadata is missing.
+
+    Returns display names (not item_ids) because callers use this for suggestions only.
+    """
+    if not menu or not protein:
+        return []
+
+    protein_key = protein.strip().lower()
+    markers: Sequence[str] = _PROTEIN_MARKERS.get(protein_key, ())
+    if not markers:
+        return []
+
+    hits: List[str] = []
     for _norm_name, iid in menu.name_choices:
         try:
             dn = (menu.display_name(iid) or "").strip()
         except Exception:
             continue
-        l = dn.lower()
+        if not dn:
+            continue
 
-        if protein == "lamb":
-            if "lamb" in l or "lam" in l:
-                out.append(dn)
-        elif protein == "chicken":
-            if "chicken" in l or "kip" in l:
-                out.append(dn)
-        elif protein == "biryani":
-            if "biryani" in l:
-                out.append(dn)
-        elif protein == "vegetarian":
-            if any(x in l for x in ["veg", "veget", "paneer", "dahl", "dal"]):
-                out.append(dn)
+        ldn = dn.lower()
+        if any(m in ldn for m in markers):
+            hits.append(dn)
 
-    seen = set()
-    dedup = []
-    for x in out:
-        if x not in seen:
-            seen.add(x)
-            dedup.append(x)
-
-    return dedup[:80]
+    return _dedup_keep_order(hits, limit=limit)
 
 
 def _spice_score(name: str) -> int:
+    """
+    Deterministic keyword-based heat proxy.
+    Used only for ranking suggestions when user asks for spicy.
+    """
     n = (name or "").lower()
     score = 0
     if "phall" in n:
@@ -105,46 +185,49 @@ def suggest_substitution(
     *,
     spicy_threshold: int = 4,
     safe_fail_threshold: float = 0.70,
+    limit: int = 3,
 ) -> Tuple[Optional[str], float, str]:
     """
     Return (suggested_item_name, confidence, reasoning).
 
     Priority:
-      1) Metadata tags (protein/heat/is_spicy)
-      2) Fallback deterministic name scoring
-      3) Safe-fail (ask clarifying question upstream)
-
-    Confidence meanings:
-      - >= safe_fail_threshold: safe to suggest 1-2 items (NO auto-add)
-      - <  safe_fail_threshold: do not suggest a specific dish
+      1) Menu metadata (protein/heat) if available
+      2) Heuristic menu scanning
+      3) Safe-fail: no specific suggestion
     """
-    if not menu or not q.protein:
+    if not menu or not q or not q.protein:
         return None, 0.0, "no-protein"
 
+    protein = q.protein.strip().lower()
+
     # ---- 1) Metadata path ----
-    # If tags exist, find_by_attributes will return item_ids
+    # MenuSnapshot may or may not implement attribute search. Keep safe.
     try:
         if q.wants_spicy:
-            ids = menu.find_by_attributes(protein=q.protein, heat_min=int(spicy_threshold), limit=3)
+            ids = menu.find_by_attributes(protein=protein, heat_min=int(spicy_threshold), limit=limit)
             if ids:
-                names = [menu.display_name(iid) for iid in ids]
-                # spiciest first
-                return names[0], 0.85, "metadata:protein+heat"
-            # protein exists but no spicy match
-            ids2 = menu.find_by_attributes(protein=q.protein, limit=3)
+                names = [menu.display_name(iid) for iid in ids if menu.display_name(iid)]
+                if names:
+                    return names[0], 0.85, "metadata:protein+heat"
+
+            # Protein exists but spicy filter didn't match
+            ids2 = menu.find_by_attributes(protein=protein, limit=limit)
             if ids2:
                 return None, 0.65, "metadata:protein-but-no-spicy-match"
             return None, 0.0, "metadata:no-candidates"
-        else:
-            ids = menu.find_by_attributes(protein=q.protein, limit=3)
-            if ids:
-                return menu.display_name(ids[0]), 0.75, "metadata:protein"
+
+        ids = menu.find_by_attributes(protein=protein, limit=limit)
+        if ids:
+            name = menu.display_name(ids[0])
+            if name:
+                return name, 0.75, "metadata:protein"
     except Exception:
         # fall through to heuristic
         pass
 
     # ---- 2) Heuristic fallback ----
-    candidates = list_items_for_protein(menu, q.protein)
+    scan_limit = 80  # safety cap: avoid huge suggestion lists
+    candidates = list_items_for_protein(menu, protein, limit=scan_limit)
     if not candidates:
         return None, 0.0, "fallback:no-candidates"
 
@@ -152,10 +235,13 @@ def suggest_substitution(
         ranked = sorted(candidates, key=_spice_score, reverse=True)
         top = ranked[0]
         top_score = _spice_score(top)
+
         if top_score >= 55:
             return top, 0.75, "fallback:protein+spicy-keyword"
+
+        # Not confident enough to recommend a specific item
         return None, 0.65, "fallback:protein-but-spice-uncertain"
 
+    # Protein-only, no spice preference: avoid overly confident picks
     ranked = sorted(candidates, key=lambda x: (len(x), x))
-    return ranked[0], 0.65, "fallback:protein-only"
-
+    return ranked[0], max(0.0, safe_fail_threshold - 0.05), "fallback:protein-only"

--- a/src/api/menu_knowledge.py
+++ b/src/api/menu_knowledge.py
@@ -55,6 +55,7 @@ _PROTEIN_MARKERS = {
     "lamb": ("lamb", "lam", "lams"),
     "chicken": ("chicken", "kip"),
     "vegetarian": ("vegetarian", "vegetarisch", "vega", "veg", "paneer"),
+    "biryani": ("biryani",),
 }
 
 

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -414,13 +414,13 @@ async def _handle_ws(ws: WebSocket) -> None:
     except Exception:
         state.heartbeat_task = None
 
-    # server does NOT speak; it only sets initial phase
     if is_dispatcher:
         state.phase = "dispatcher"
     else:
-        # keep whatever your non-dispatcher default is
-        # e.g. "chat" or "language_select"
         state.phase = getattr(state, "phase", "chat")
+
+    # Connect tick (server stays string-free; engines own greeting)
+    await controller.on_connect(ws)
 
     vad = VAD(
         frame_ms=settings.AUDIO_FRAME_MS,
@@ -593,11 +593,6 @@ async def _handle_ws(ws: WebSocket) -> None:
         except Exception:
             pass
         try:
-            if state.proc_task and not state.proc_task.done():
-                state.proc_task.cancel()
-        except Exception:
-            pass
-        try:
             if state.tts_task and not state.tts_task.done():
                 state.tts_task.cancel()
         except Exception:
@@ -606,7 +601,6 @@ async def _handle_ws(ws: WebSocket) -> None:
             await ws.close()
         except Exception:
             pass
-
 
 @app.websocket("/ws_pcm")
 async def ws_pcm(ws: WebSocket) -> None:

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -450,6 +450,12 @@ async def _handle_ws(ws: WebSocket) -> None:
     # Extra patience if the buffered utter is "short" (likely stutter / incomplete thought)
     PAUSE_MERGE_SEC_FRAGMENT = settings.PAUSE_MERGE_SEC_FRAGMENT
     FRAGMENT_MAX_BYTES = settings.FRAGMENT_MAX_BYTES # ~0.5s at 16kHz * 16-bit mono (adjust if your PCM differs)
+    logger.info(
+        "[seg_cfg] PAUSE_MERGE_SEC=%.2f PAUSE_MERGE_SEC_FRAGMENT=%.2f FRAGMENT_MAX_BYTES=%d",
+        PAUSE_MERGE_SEC,
+        PAUSE_MERGE_SEC_FRAGMENT,
+        FRAGMENT_MAX_BYTES,
+    )
 
     # Server-side barge-in on audio energy (in case client doesn't send "barge_in")
     # tune, start ~350-600 depending on mic/noise

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -450,12 +450,6 @@ async def _handle_ws(ws: WebSocket) -> None:
     # Extra patience if the buffered utter is "short" (likely stutter / incomplete thought)
     PAUSE_MERGE_SEC_FRAGMENT = settings.PAUSE_MERGE_SEC_FRAGMENT
     FRAGMENT_MAX_BYTES = settings.FRAGMENT_MAX_BYTES # ~0.5s at 16kHz * 16-bit mono (adjust if your PCM differs)
-    logger.info(
-        "[seg_cfg] PAUSE_MERGE_SEC=%.2f PAUSE_MERGE_SEC_FRAGMENT=%.2f FRAGMENT_MAX_BYTES=%d",
-        PAUSE_MERGE_SEC,
-        PAUSE_MERGE_SEC_FRAGMENT,
-        FRAGMENT_MAX_BYTES,
-    )
 
     # Server-side barge-in on audio energy (in case client doesn't send "barge_in")
     # tune, start ~350-600 depending on mic/noise

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -240,6 +240,7 @@ async def tenant_config(tenant: str = "default") -> JSONResponse:
     greet = _tenant_greeting_from_rules(tmp_state)
     if not greet and tenant_ref == "taj_mahal":
         greet = greeting_text_taj(tmp_state.lang)
+
     if not greet:
         greet = (
             "Hi, this is Voxeron. Which service do you need?"
@@ -257,7 +258,6 @@ async def tenant_config(tenant: str = "default") -> JSONResponse:
             "greeting": greet,
         }
     )
-
 
 async def heartbeat_loop(ws: WebSocket, controller: SessionController) -> None:
     """
@@ -414,20 +414,13 @@ async def _handle_ws(ws: WebSocket) -> None:
     except Exception:
         state.heartbeat_task = None
 
-    greet = _tenant_greeting_from_rules(state)
-    if not greet and state.tenant_ref == "taj_mahal":
-        greet = greeting_text_taj(state.lang)
-    if not greet:
-        greet = "Hi, this is Voxeron. Which service do you need?"
-
+    # server does NOT speak; it only sets initial phase
     if is_dispatcher:
         state.phase = "dispatcher"
-
-    await send_agent_text(ws, greet)
-    await controller.stream_tts_mp3(ws, greet)
-
-    state.last_agent_speech_end_ts = time.time()
-    state.last_activity_ts = state.last_agent_speech_end_ts
+    else:
+        # keep whatever your non-dispatcher default is
+        # e.g. "chat" or "language_select"
+        state.phase = getattr(state, "phase", "chat")
 
     vad = VAD(
         frame_ms=settings.AUDIO_FRAME_MS,

--- a/src/api/session_controller.py
+++ b/src/api/session_controller.py
@@ -11,14 +11,9 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import WebSocket
 
-from .intent import (
-    detect_language_intent,
-    norm_simple,
-    detect_generic_nan_request,
-    detect_explicit_remove_intent,
-)
+from .intent import detect_language_intent, norm_simple
+
 from .menu_store import MenuSnapshot, MenuStore
-from .menu_knowledge import extract_naan_variant_keyword_scoped, is_naan_item, naan_optima_prompt, find_naan_item_for_variant
 from .tenant_manager import TenantManager, TenantConfig
 from .policy import (
     SessionPolicyState,
@@ -26,6 +21,8 @@ from .policy import (
 )
 from .services.openai_client import OpenAIClient
 from .telemetry.emitter import TelemetryEmitter, TelemetryContext
+from .engine.router import DomainRouter
+from .engine.types import PlanAction
 
 # Orchestrator is optional; never crash if it is unavailable.
 try:
@@ -162,6 +159,7 @@ class SessionState:
     lang_candidate: Optional[str] = None
     lang_candidate_count: int = 0
 
+    dispatcher_greeted: bool = False
 
 QTY_MAP_NL = {"een": 1, "één": 1, "1": 1, "twee": 2, "2": 2, "drie": 3, "3": 3, "vier": 4, "4": 4}
 QTY_MAP_EN = {"one": 1, "1": 1, "two": 2, "2": 2, "three": 3, "3": 3, "four": 4, "4": 4}
@@ -325,6 +323,7 @@ class SessionController:
         self.send_thinking = send_thinking
         self.clear_thinking = clear_thinking
         self.tts_end = tts_end
+        self.domain_router = DomainRouter()
 
     # -------------------------
     # UX strings
@@ -410,13 +409,6 @@ class SessionController:
             return False
         return len(t_raw.split()) <= 3
 
-    # -------------------------
-    # Menu helpers
-    # -------------------------
-
-
-
-
     def _parse_fulfillment(self, text: str) -> Optional[str]:
         t = norm_simple(text)
         if any(x in t for x in ["pickup", "pick up", "takeaway", "collection", "for pickup", "afhalen", "ophalen", "meenemen", "to go", "togo"]):
@@ -424,34 +416,7 @@ class SessionController:
         if any(x in t for x in ["delivery", "deliver", "for delivery", "bezorgen", "bezorging"]):
             return "delivery"
         return None
-
-    def _is_dispatcher(self) -> bool:
-        if self.state.phase == "dispatcher":
-            return True
-        cfg = self.state.tenant_cfg
-        if cfg and getattr(cfg, "domain_type", None) == "dispatcher":
-            return True
-        if self.state.tenant_ref == "voxeron_main":
-            return True
-        return False
-
-    def _dispatcher_route(self, text: str) -> Optional[str]:
-        t = norm_simple(text)
-        turkish = ["tesisat", "tesisatçı", "tamir", "sızınt", "boru", "su bas", "gaz kok"]
-        plumber_nl = ["loodgieter", "lekkage", "spoed", "water", "leiding", "verstopping", "afvoer"]
-        plumber_en = ["plumber", "leak", "burst", "pipe", "flood", "repair", "emergency"]
-        food_nl = ["eten", "bestellen", "indiaas", "restaurant", "afhalen", "bezorgen"]
-        food_en = ["food", "hungry", "order", "restaurant", "indian"]
-
-        if any(k in t for k in turkish):
-            return "abt"
-        if any(k in t for k in plumber_nl) or any(k in t for k in plumber_en):
-            return "abt"
-        if any(k in t for k in food_nl) or any(k in t for k in food_en):
-            return "taj_mahal"
-        return None
-
-
+    
     def _taj_overlay_alias_map(self, menu: MenuSnapshot) -> Dict[str, str]:
         """
         Map TAJ_EXTRA_ALIASES (display-name style) to actual item_ids where possible.
@@ -568,7 +533,24 @@ class SessionController:
                 return (iid, new_qty)
 
         return None
-
+    
+    def _apply_cart_ops(self, st: "SessionState", ops: list[dict]) -> bool:
+        changed = False
+        for op in ops or []:
+            kind = (op.get("op") or "").strip().lower()
+            if kind == "add":
+                item_id = op.get("item_id")
+                qty = int(op.get("qty", 1) or 1)
+                if item_id:
+                    st.order.add(item_id, max(1, qty))
+                    changed = True
+            elif kind == "set_qty":
+                item_id = op.get("item_id")
+                qty = int(op.get("qty", 1) or 1)
+                if item_id:
+                    st.order.set_qty(item_id, qty)
+                    changed = True
+        return changed
 
     async def _load_tenant_context(self, tenant_ref: str) -> None:
         st = self.state
@@ -603,6 +585,14 @@ class SessionController:
             st.stt_lang_hint = None
             st.lang_candidate = None
             st.lang_candidate_count = 0
+
+    async def _hotswap_tenant(self, ws: WebSocket, target: str) -> None:
+            """
+            Switch tenant/domain mid-session.
+            No greeting, no speech. Engines decide what to say next.
+            """
+            await self._load_tenant_context(target)
+            self.state.phase = "chat"
 
     async def _speak(self, ws: WebSocket, text: str) -> None:
         await self.send_agent_text(ws, text)
@@ -854,51 +844,6 @@ class SessionController:
                 if st.tenant_ref == "taj_mahal" and st.lang == "nl":
                     st.stt_lang_hint = "nl"
 
-            allow_auto = not (st.tenant_ref == "taj_mahal" and st.lang != "nl")
-            _ = detect_language_intent(
-                transcript,
-                phase=st.phase,
-                current_lang=st.lang,
-                allow_auto_detect=allow_auto,
-            )
-
-            # ==========================================================
-            # 3) Dispatcher routing
-            # ==========================================================
-            if self._is_dispatcher():
-                target = self._dispatcher_route(transcript)
-                if not target:
-                    await self.clear_thinking(ws)
-                    await self._speak(ws, "Hi, this is Voxeron. Which service do you need?")
-                    return
-
-                await self.clear_thinking(ws)
-                if target == "taj_mahal":
-                    await self._speak(ws, "Okay — connecting you now." if st.lang != "nl" else "Prima — ik verbind u nu door.")
-                    logger.info("[hot_swap] from=%s to=%s", st.tenant_ref, target)
-                    await self._load_tenant_context(target)
-                    st.phase = "chat"
-                    taj_greet = (
-                        "Hi! Welcome to Taj Mahal Bussum. You can start ordering now. If you want Dutch, say 'Nederlands'."
-                        if st.lang != "nl"
-                        else "Welkom bij Taj Mahal Bussum. Je kunt nu bestellen."
-                    )
-                    await self._speak(ws, taj_greet)
-                    return
-
-                if target == "abt":
-                    await self._speak(ws, "Okay — connecting you now." if st.lang != "nl" else "Prima — ik verbind u nu door.")
-                    logger.info("[hot_swap] from=%s to=%s", st.tenant_ref, target)
-                    await self._load_tenant_context(target)
-                    st.phase = "chat"
-                    await self._speak(ws, "Alphabouwtechniek. Wat is er aan de hand?")
-                    return
-                
-                logger.info(
-                    "[proc_utt] transcript_len=%s text=%r",
-                    len(transcript or ""),
-                    (transcript or "")[:80],
-                )
             # ==========================================================
             # 4) Deterministic prompt-dump filter
             # ==========================================================
@@ -1012,18 +957,55 @@ class SessionController:
                 msg = f"Thank you, {st.customer_name}. {self._say_anything_else()}" if st.lang != "nl" else f"Dank je, {st.customer_name}. {self._say_anything_else()}"
                 await self._speak(ws, msg)
                 return
+ 
+            # ==========================================================
+            # 5.5) Domain engine hook (must run BEFORE ordering logic)
+            # ==========================================================
+            plan = self.domain_router.plan(st, transcript)
+
+            # apply pending gate updates (menu-blind)
+            if plan.pending_choice is not None:
+                st.pending_choice = plan.pending_choice
+                st.pending_qty = max(1, int(plan.pending_qty or 1))
+
+            # resolved choice clears the gate (menu-blind)
+            if plan.resolved_choice is not None:
+                st.pending_choice = None
+                st.pending_qty = max(1, int(plan.resolved_choice.qty or 1))
+
+            # apply generic cart ops if any
+            applied_ops = False
+            if plan.cart_ops:
+                applied_ops = self._apply_cart_ops(st, plan.cart_ops)
+
+            # hot swap target tenant if requested
+            if plan.hotswap_tenant_ref:
+                target = plan.hotswap_tenant_ref
+                logger.info("[hot_swap] from=%s to=%s", st.tenant_ref, target)
+                await self._hotswap_tenant(ws, target)
+                return
+
+            # engine wants us to speak now
+            if plan.action in (PlanAction.REPLY, PlanAction.CLARIFY):
+                await self.clear_thinking(ws)
+                if plan.reply:
+                    await self._speak(ws, plan.reply)
+                return
+
+            engine_added_any = bool(applied_ops)
 
             # ==========================================================
-            # 6) Ordering logic (Deterministic add + naan scoping)
+            # 6) Ordering logic (Deterministic add)  ✅ menu-blind here
             # ==========================================================
             add_qty = (_extract_qty_first(transcript, "en") or _extract_qty_first(transcript, "nl") or 1)
             effective_qty = add_qty
 
             cart_before = st.order.summary(st.menu) if st.menu else ""
-            added_any = False
+            added_any = bool(engine_added_any)
             added_ids: List[str] = []
 
             if st.menu:
+                # Temporary deterministic alias overlay for Taj (still menu-blind: just alias → display-name match)
                 if st.tenant_ref == "taj_mahal":
                     tok = norm_simple(transcript).strip()
                     if tok in TAJ_EXTRA_ALIASES and TAJ_EXTRA_ALIASES[tok] != "__GLOBAL_ORDER__":
@@ -1040,45 +1022,7 @@ class SessionController:
                 orch_item_id = self._maybe_orchestrator_match_item(st.menu, transcript, int(effective_qty or 1))
                 adds = [] if orch_item_id else parse_add_item(st.menu, transcript, qty=effective_qty)
 
-                mentions_nan = (" naan " in (" " + norm_simple(transcript) + " ")) or detect_generic_nan_request(transcript)
-                variant = extract_naan_variant_keyword_scoped(transcript)
-                has_variant = bool(variant)
-
-                logger.info(
-                    "naan_check mentions_nan=%s has_variant=%s variant=%s",
-                    mentions_nan, has_variant, variant,
-                )
-
-                if mentions_nan and (not has_variant):
-                    non_nan_hits: List[Tuple[str, int]] = []
-                    for item_id, qty in adds:
-                        if not is_naan_item(st.menu, item_id):
-                            non_nan_hits.append((item_id, qty))
-
-                    for item_id, qty in non_nan_hits:
-                        st.order.add(item_id, qty)
-                        added_any = True
-                        added_ids.append(item_id)
-
-                    st.pending_choice = "nan_variant"
-                    st.pending_qty = max(1, int(effective_qty or 1))
-                    st.nan_prompt_count = 0
-
-                    await self.clear_thinking(ws)
-                    await self._speak(ws, naan_optima_prompt(st.menu, st.lang, list_mode="short", with_main=None))
-                    return
-
-                if mentions_nan and has_variant:
-                    iid = find_naan_item_for_variant(st.menu, variant or "")
-                    if iid:
-                        st.order.add(iid, max(1, int(effective_qty or 1)))
-                        added_any = True
-                        added_ids.append(iid)
-                        adds = [(x, q) for (x, q) in adds if x != iid and not is_naan_item(st.menu, x)]
-
                 for item_id, qty in adds:
-                    if mentions_nan and has_variant and is_naan_item(st.menu, item_id):
-                        continue
                     st.order.add(item_id, qty)
                     added_any = True
                     added_ids.append(item_id)
@@ -1094,7 +1038,12 @@ class SessionController:
 
                 if st.fulfillment_mode == "pickup" and not st.customer_name:
                     st.pending_name = True
-                    await self._speak(ws, "Great. What name should I put the order under?" if st.lang != "nl" else "Prima. Op welke naam mag ik de bestelling zetten?")
+                    await self._speak(
+                        ws,
+                        "Great. What name should I put the order under?"
+                        if st.lang != "nl"
+                        else "Prima. Op welke naam mag ik de bestelling zetten?",
+                    )
                     return
 
                 await self._speak(ws, self._say_anything_else())

--- a/src/api/session_controller.py
+++ b/src/api/session_controller.py
@@ -11,7 +11,11 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import WebSocket
 
-from .intent import detect_language_intent, norm_simple
+from .intent import (
+    detect_language_intent,
+    detect_explicit_remove_intent,
+    norm_simple,
+)
 
 from .menu_store import MenuSnapshot, MenuStore
 from .tenant_manager import TenantManager, TenantConfig
@@ -22,7 +26,7 @@ from .policy import (
 from .services.openai_client import OpenAIClient
 from .telemetry.emitter import TelemetryEmitter, TelemetryContext
 from .engine.router import DomainRouter
-from .engine.types import PlanAction
+from .engine.types import PlanAction, ResponsePlan
 
 # Orchestrator is optional; never crash if it is unavailable.
 try:
@@ -534,19 +538,23 @@ class SessionController:
 
         return None
     
-    def _apply_cart_ops(self, st: "SessionState", ops: list[dict]) -> bool:
+    def _apply_cart_ops(self, st: "SessionState", ops) -> bool:
         changed = False
         for op in ops or []:
-            kind = (op.get("op") or "").strip().lower()
-            if kind == "add":
+            if hasattr(op, "op") and hasattr(op, "item_id"):
+                kind = (op.op or "").strip().lower()
+                item_id = op.item_id
+                qty = int(getattr(op, "qty", 1) or 1)
+            else:
+                kind = (op.get("op") or "").strip().lower()
                 item_id = op.get("item_id")
                 qty = int(op.get("qty", 1) or 1)
+
+            if kind == "add":
                 if item_id:
                     st.order.add(item_id, max(1, qty))
                     changed = True
             elif kind == "set_qty":
-                item_id = op.get("item_id")
-                qty = int(op.get("qty", 1) or 1)
                 if item_id:
                     st.order.set_qty(item_id, qty)
                     changed = True
@@ -593,6 +601,7 @@ class SessionController:
             """
             await self._load_tenant_context(target)
             self.state.phase = "chat"
+            setattr(self.state, "restaurant_greeted", False)
 
     async def _speak(self, ws: WebSocket, text: str) -> None:
         await self.send_agent_text(ws, text)
@@ -632,6 +641,52 @@ class SessionController:
         try:
             await st.tts_task
         except asyncio.CancelledError:
+            return
+
+    async def on_connect(self, ws: WebSocket) -> None:
+        """
+        Connect-tick: allow engines to emit a first prompt (e.g. dispatcher greeting)
+        without requiring user audio / STT. Server stays string-free.
+        """
+        st = self.state
+
+        plan = self.domain_router.plan(st, "")
+
+        # apply pending gate updates (menu-blind)
+        if plan.pending_choice is not None:
+            st.pending_choice = plan.pending_choice
+            st.pending_qty = max(1, int(plan.pending_qty or 1))
+
+        # resolved choice clears the gate (menu-blind)
+        if plan.resolved_choice is not None:
+            st.pending_choice = None
+            st.pending_qty = max(1, int(plan.resolved_choice.qty or 1))
+
+        # apply generic cart ops if any
+        if plan.cart_ops:
+            self._apply_cart_ops(st, plan.cart_ops)
+
+        # hot swap target tenant if requested
+        if plan.hotswap_tenant_ref:
+            await self.clear_thinking(ws)
+
+            # speak connect message (engine-owned)
+            if plan.reply:
+                await self._speak(ws, plan.reply)
+
+            target = plan.hotswap_tenant_ref
+            logger.info("[hot_swap] from=%s to=%s", st.tenant_ref, target)
+            await self._hotswap_tenant(ws, target)
+
+            # greet the new tenant/domain (engine-owned)
+            await self.on_connect(ws)
+            return
+        
+        # speak greeting / question
+        if plan.action in (PlanAction.REPLY, PlanAction.CLARIFY):
+            await self.clear_thinking(ws)
+            if plan.reply:
+                await self._speak(ws, plan.reply)
             return
 
     async def process_utterance(self, ws: WebSocket, pcm: bytes) -> None:
@@ -962,6 +1017,9 @@ class SessionController:
             # 5.5) Domain engine hook (must run BEFORE ordering logic)
             # ==========================================================
             plan = self.domain_router.plan(st, transcript)
+            if plan is None:
+                logger.error("CRITICAL: domain_router.plan returned None (phase=%s)", getattr(st, "phase", ""))
+                plan = ResponsePlan(action=PlanAction.NOOP, reply="", lang=getattr(st, "lang", "en") or "en")
 
             # apply pending gate updates (menu-blind)
             if plan.pending_choice is not None:
@@ -980,9 +1038,18 @@ class SessionController:
 
             # hot swap target tenant if requested
             if plan.hotswap_tenant_ref:
+                await self.clear_thinking(ws)
+
+                # speak connect message (engine-owned)
+                if plan.reply:
+                    await self._speak(ws, plan.reply)
+
                 target = plan.hotswap_tenant_ref
                 logger.info("[hot_swap] from=%s to=%s", st.tenant_ref, target)
                 await self._hotswap_tenant(ws, target)
+
+                # greet the new tenant/domain (engine-owned)
+                await self.on_connect(ws)
                 return
 
             # engine wants us to speak now

--- a/src/api/session_controller.py
+++ b/src/api/session_controller.py
@@ -1007,10 +1007,9 @@ class SessionController:
                 variant = extract_naan_variant_keyword_scoped(transcript)
                 has_variant = bool(variant)
 
-                naan_opts = self._naan_options_from_menu(st.menu)
                 logger.info(
-                    "naan_check mentions_nan=%s has_variant=%s variant=%s naan_opts=%d opts=%s",
-                    mentions_nan, has_variant, variant, len(naan_opts), [x[0] for x in naan_opts[:5]],
+                    "naan_check mentions_nan=%s has_variant=%s variant=%s",
+                    mentions_nan, has_variant, variant,
                 )
 
                 if mentions_nan and (not has_variant):

--- a/src/api/session_controller.py
+++ b/src/api/session_controller.py
@@ -595,13 +595,13 @@ class SessionController:
             st.lang_candidate_count = 0
 
     async def _hotswap_tenant(self, ws: WebSocket, target: str) -> None:
-            """
-            Switch tenant/domain mid-session.
-            No greeting, no speech. Engines decide what to say next.
-            """
-            await self._load_tenant_context(target)
-            self.state.phase = "chat"
-            setattr(self.state, "restaurant_greeted", False)
+        """
+        Switch tenant/domain mid-session.
+        No greeting, no speech. Engines decide what to say next.
+        """
+        await self._load_tenant_context(target)
+        self.state.phase = "chat"
+        setattr(self.state, "restaurant_greeted", False)
 
     async def _speak(self, ws: WebSocket, text: str) -> None:
         await self.send_agent_text(ws, text)
@@ -645,49 +645,36 @@ class SessionController:
 
     async def on_connect(self, ws: WebSocket) -> None:
         """
-        Connect-tick: allow engines to emit a first prompt (e.g. dispatcher greeting)
+        Connect-tick: allow engines to emit a first prompt (greeting / clarify)
         without requiring user audio / STT. Server stays string-free.
         """
         st = self.state
 
         plan = self.domain_router.plan(st, "")
 
-        # apply pending gate updates (menu-blind)
-        if plan.pending_choice is not None:
-            st.pending_choice = plan.pending_choice
-            st.pending_qty = max(1, int(plan.pending_qty or 1))
+        # Defensive: engines must return a ResponsePlan
+        if plan is None:
+            logger.error("CRITICAL: DomainRouter.plan returned None (phase=%s)", getattr(st, "phase", ""))
+            return
 
-        # resolved choice clears the gate (menu-blind)
-        if plan.resolved_choice is not None:
-            st.pending_choice = None
-            st.pending_qty = max(1, int(plan.resolved_choice.qty or 1))
-
-        # apply generic cart ops if any
-        if plan.cart_ops:
-            self._apply_cart_ops(st, plan.cart_ops)
-
-        # hot swap target tenant if requested
+        # If engine requests a hotswap on connect, execute it (speak connect message once)
         if plan.hotswap_tenant_ref:
-            await self.clear_thinking(ws)
-
-            # speak connect message (engine-owned)
             if plan.reply:
+                await self.clear_thinking(ws)
                 await self._speak(ws, plan.reply)
 
             target = plan.hotswap_tenant_ref
             logger.info("[hot_swap] from=%s to=%s", st.tenant_ref, target)
             await self._hotswap_tenant(ws, target)
 
-            # greet the new tenant/domain (engine-owned)
+            # Now greet the new domain/tenant (engine-owned)
             await self.on_connect(ws)
             return
-        
-        # speak greeting / question
-        if plan.action in (PlanAction.REPLY, PlanAction.CLARIFY):
+
+        # Otherwise speak greeting / clarify if provided
+        if plan.action in (PlanAction.REPLY, PlanAction.CLARIFY) and plan.reply:
             await self.clear_thinking(ws)
-            if plan.reply:
-                await self._speak(ws, plan.reply)
-            return
+            await self._speak(ws, plan.reply)
 
     async def process_utterance(self, ws: WebSocket, pcm: bytes) -> None:
         st = self.state
@@ -1040,7 +1027,7 @@ class SessionController:
             if plan.hotswap_tenant_ref:
                 await self.clear_thinking(ws)
 
-                # speak connect message (engine-owned)
+                # speak connect message ONCE (engine-owned)
                 if plan.reply:
                     await self._speak(ws, plan.reply)
 

--- a/src/api/session_controller.py
+++ b/src/api/session_controller.py
@@ -927,8 +927,14 @@ class SessionController:
             # 5) Slot handling (Intent-aware, non-greedy)
             # ==========================================================
             # Fulfillment slot (intent-aware, non-greedy)
-            if st.pending_fulfillment and not (is_ordering_intent or looks_like_order_payload):
-
+            # Guard: if user continues ordering while we are waiting for pickup/delivery,
+            # do NOT route into ordering (naan prompts, etc.). Re-ask fulfillment and return.
+            if st.pending_fulfillment and (is_ordering_intent or looks_like_order_payload):
+                logger.info("[guard] ordering payload during pending_fulfillment -> re-ask fulfillment")
+                await self.clear_thinking(ws)
+                await self._speak(ws, self._say_pickup_or_delivery())
+                return
+            if st.pending_fulfillment:
                 if self._is_obvious_out_of_scope(transcript):
                     await self.clear_thinking(ws)
                     await self._speak(ws, "I can help with the order — is this for pickup or delivery?")
@@ -976,6 +982,24 @@ class SessionController:
 
                 if self._is_refusal_like(transcript):
                     await self._speak(ws, "No problem. What name should I put the order under?")
+                    return
+                
+                # Guard: user answered fulfillment or continued ordering while we asked for name.
+                mode = self._parse_fulfillment(transcript)
+                if mode in ("pickup", "delivery"):
+                    await self._speak(ws, "Thanks — what name should I put the order under?")
+                    return
+
+                tnorm_name = " " + norm_simple(transcript) + " "
+                if any(
+                    x in tnorm_name
+                    for x in (
+                        " one ", " two ", " three ", " four ", " five ", " six ", " seven ", " eight ", " nine ", " ten ",
+                        " 1 ", " 2 ", " 3 ", " 4 ", " 5 ", " 6 ", " 7 ", " 8 ", " 9 ",
+                        " een ", " twee ", " drie ", " vier ", " vijf ", " zes ", " zeven ", " acht ", " negen ", " tien ",
+                    )
+                ):
+                    await self._speak(ws, "Got it — what name should I put the order under?")
                     return
 
                 if not self._looks_like_name_answer(transcript):

--- a/src/api/session_controller.py
+++ b/src/api/session_controller.py
@@ -18,6 +18,7 @@ from .intent import (
     detect_explicit_remove_intent,
 )
 from .menu_store import MenuSnapshot, MenuStore
+from .menu_knowledge import extract_naan_variant_keyword_scoped, is_naan_item, naan_optima_prompt, find_naan_item_for_variant
 from .tenant_manager import TenantManager, TenantConfig
 from .policy import (
     SessionPolicyState,
@@ -285,56 +286,6 @@ async def llm_turn(oa: OpenAIClient, state: SessionState, user_text: str, menu_c
     return obj if obj else {"reply": txt, "add": [], "remove": []}
 
 
-# -------------------------
-# Naan keyword parsing (SCOPED)
-# -------------------------
-_NAAN_TOKENS = {"naan", "nan", "naam"}
-_PLAIN_LIKE = {
-    "plain", "regular", "normal", "gewoon", "normaal", "standaard",
-    "plainer", "plainar", "planar", "plano", "playn", "plean",
-}
-_VARIANT_TOKS = {
-    "garlic": {"garlic", "knoflook"},
-    "butter": {"butter", "boter"},
-    "cheese": {"cheese", "kaas"},
-    "keema": {"keema", "kheema"},
-    "peshawari": {"peshawari"},
-}
-
-
-def _extract_nan_variant_keyword_scoped(text: str) -> Optional[str]:
-    t = norm_simple(text)
-    if not t:
-        return None
-    toks = t.split()
-    naan_idxs = [i for i, tok in enumerate(toks) if tok in _NAAN_TOKENS]
-    if not naan_idxs:
-        return None
-
-    def window(i: int, r: int = 3) -> List[str]:
-        lo = max(0, i - r)
-        hi = min(len(toks), i + r + 1)
-        return toks[lo:hi]
-
-    for idx in naan_idxs:
-        w = window(idx, 3)
-        if any(tok in _PLAIN_LIKE for tok in w):
-            return "plain"
-
-    for idx in naan_idxs:
-        w = set(window(idx, 3))
-        for canonical, variants in _VARIANT_TOKS.items():
-            if w.intersection(variants):
-                return canonical
-
-    joined = " " + " ".join(toks) + " "
-    for canonical, variants in _VARIANT_TOKS.items():
-        for v in variants:
-            if f" {v} naan " in joined or f" naan {v} " in joined or f" {v} nan " in joined or f" nan {v} " in joined:
-                return canonical
-
-    return None
-
 
 class SessionController:
     def __init__(
@@ -462,119 +413,9 @@ class SessionController:
     # -------------------------
     # Menu helpers
     # -------------------------
-    def _is_nan_item(self, menu: MenuSnapshot, item_id: str) -> bool:
-        dn = (menu.display_name(item_id) or "").lower()
-        return ("naan" in dn) or ("nan" in dn) or ("naam" in dn)
 
-    def _naan_options_from_menu(self, menu: MenuSnapshot) -> List[Tuple[str, str]]:
-        if not menu:
-            return []
-        items: List[Tuple[str, str]] = []
-        for _name, iid in menu.name_choices:
-            if not self._is_nan_item(menu, iid):
-                continue
-            label = (menu.display_name(iid) or "").strip()
-            if label:
-                items.append((label, iid))
-        if not items:
-            return []
 
-        prefs = [
-            ("garlic", ["garlic", "knoflook"]),
-            ("plain", ["naan", "nan", "plain", "regular", "normal", "gewoon", "standaard"]),
-            ("butter", ["butter", "boter"]),
-            ("cheese", ["cheese", "kaas"]),
-            ("keema", ["keema", "kheema"]),
-            ("peshawari", ["peshawari"]),
-        ]
 
-        def score(label: str) -> int:
-            ll = label.lower().strip()
-            if ll in {"nan", "naan"}:
-                return 120
-            for i, (_k, toks) in enumerate(prefs):
-                if any(t in ll for t in toks):
-                    return 100 - i
-            return 0
-
-        items.sort(key=lambda x: (score(x[0]), -len(x[0])), reverse=True)
-        return items
-
-    def _naan_optima_prompt(self, *, list_mode: str = "short", with_main: Optional[str] = None) -> str:
-        st = self.state
-        menu = st.menu
-        opts = self._naan_options_from_menu(menu) if menu else []
-        max_n = 2 if list_mode == "short" else 4
-
-        if not opts:
-            if st.lang != "nl":
-                return (
-                    f"Certainly. Would you like plain naan or garlic naan with your {with_main}?"
-                    if with_main
-                    else "Which naan would you like, plain or garlic?"
-                )
-            return (
-                f"Zeker. Wil je plain naan of garlic naan bij je {with_main}?"
-                if with_main
-                else "Welke naan wil je, plain of garlic?"
-            )
-
-        picked = opts[:max_n]
-        labels = [p[0] for p in picked]
-
-        if st.lang != "nl":
-            if with_main and len(labels) >= 2:
-                return f"Certainly. Would you like {labels[0]} or {labels[1]} with your {with_main}?"
-            if len(labels) >= 2:
-                return f"Would you like {labels[0]} or {labels[1]}?"
-            return f"We have {labels[0]}. Would you like that?"
-        else:
-            if with_main and len(labels) >= 2:
-                return f"Zeker. Wil je {labels[0]} of {labels[1]} bij je {with_main}?"
-            if len(labels) >= 2:
-                return f"Wil je {labels[0]} of {labels[1]}?"
-            return f"We hebben {labels[0]}. Wil je die?"
-
-    def _find_naan_item_for_variant(self, menu: MenuSnapshot, variant: str) -> Optional[str]:
-        if not menu or not variant:
-            return None
-        v = variant.lower().strip()
-        opts = self._naan_options_from_menu(menu)
-        if not opts:
-            return None
-
-        best: Optional[str] = None
-        best_score = -10
-
-        for label, iid in opts:
-            ll = label.lower().strip()
-            s = 0
-
-            if v == "plain":
-                if ll in {"nan", "naan"}:
-                    s += 50
-                if any(t in ll for t in ["plain", "regular", "normal", "gewoon", "standaard"]):
-                    s += 20
-
-            if v == "garlic" and any(t in ll for t in ["garlic", "knoflook"]):
-                s += 25
-            if v == "butter" and any(t in ll for t in ["butter", "boter"]):
-                s += 25
-            if v == "cheese" and any(t in ll for t in ["cheese", "kaas"]):
-                s += 25
-            if v == "keema" and "keema" in ll:
-                s += 25
-            if v == "peshawari" and "peshawari" in ll:
-                s += 25
-
-            if v in ll:
-                s += 8
-
-            if s > best_score:
-                best_score = s
-                best = iid
-
-        return best if best_score >= 0 else None
 
     def _parse_fulfillment(self, text: str) -> Optional[str]:
         t = norm_simple(text)
@@ -1163,7 +1004,7 @@ class SessionController:
                 adds = [] if orch_item_id else parse_add_item(st.menu, transcript, qty=effective_qty)
 
                 mentions_nan = (" naan " in (" " + norm_simple(transcript) + " ")) or detect_generic_nan_request(transcript)
-                variant = _extract_nan_variant_keyword_scoped(transcript)
+                variant = extract_naan_variant_keyword_scoped(transcript)
                 has_variant = bool(variant)
 
                 naan_opts = self._naan_options_from_menu(st.menu)
@@ -1175,7 +1016,7 @@ class SessionController:
                 if mentions_nan and (not has_variant):
                     non_nan_hits: List[Tuple[str, int]] = []
                     for item_id, qty in adds:
-                        if not self._is_nan_item(st.menu, item_id):
+                        if not is_naan_item(st.menu, item_id):
                             non_nan_hits.append((item_id, qty))
 
                     for item_id, qty in non_nan_hits:
@@ -1188,19 +1029,19 @@ class SessionController:
                     st.nan_prompt_count = 0
 
                     await self.clear_thinking(ws)
-                    await self._speak(ws, self._naan_optima_prompt(list_mode="short", with_main="Butter Chicken" if "butter chicken" in norm_simple(transcript) else None))
+                    await self._speak(ws, naan_optima_prompt(st.menu, st.lang, list_mode="short", with_main=None))
                     return
 
                 if mentions_nan and has_variant:
-                    iid = self._find_naan_item_for_variant(st.menu, variant or "")
+                    iid = find_naan_item_for_variant(st.menu, variant or "")
                     if iid:
                         st.order.add(iid, max(1, int(effective_qty or 1)))
                         added_any = True
                         added_ids.append(iid)
-                        adds = [(x, q) for (x, q) in adds if x != iid and not self._is_nan_item(st.menu, x)]
+                        adds = [(x, q) for (x, q) in adds if x != iid and not is_naan_item(st.menu, x)]
 
                 for item_id, qty in adds:
-                    if mentions_nan and has_variant and self._is_nan_item(st.menu, item_id):
+                    if mentions_nan and has_variant and is_naan_item(st.menu, item_id):
                         continue
                     st.order.add(item_id, qty)
                     added_any = True

--- a/src/api/session_controller.py
+++ b/src/api/session_controller.py
@@ -821,12 +821,25 @@ class SessionController:
                 st.pending_name = False
                 st.pending_fulfillment = False
 
-            elif is_ordering_intent and (st.pending_fulfillment or st.pending_name):
+            elif is_ordering_intent and st.pending_fulfillment:
                 logger.info(
-                    "[v0.7.7] Global Guard: ordering intent seen during slot-fill; ROUTE TO ORDERING (pending_name=%s pending_fulfillment=%s)",
+                    "[v0.7.7] Global Guard: ordering intent seen during fulfillment slot-fill; RE-ASK FULFILLMENT (pending_name=%s pending_fulfillment=%s)",
                     st.pending_name,
                     st.pending_fulfillment,
                 )
+                # pending_fulfillment is a HARD gate: do not process ordering until resolved
+                await self.clear_thinking(ws)
+                await self._speak(ws, self._say_pickup_or_delivery())
+                return
+
+            elif is_ordering_intent and st.pending_name:
+                logger.info(
+                    "[v0.7.7] Global Guard: ordering intent seen during name slot-fill; ROUTE TO ORDERING (pending_name=%s pending_fulfillment=%s)",
+                    st.pending_name,
+                    st.pending_fulfillment,
+                )
+                # Do NOT clear pending_fulfillment/pending_name here.
+
                 # IMPORTANT:
                 # Do NOT clear pending_fulfillment/pending_name here.
                 # Do NOT return; ordering logic below should handle this transcript.

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -76,8 +76,10 @@ VAD_DEBUG = _get_bool("VAD_DEBUG", "0")
 # --------------------------------------------------
 # Utterance merge / interruption control (server policy)
 # --------------------------------------------------
+#PAUSE_MERGE_SEC = _get_float("PAUSE_MERGE_SEC", "2.8")
 PAUSE_MERGE_SEC = _get_float("PAUSE_MERGE_SEC", "2.8")
-PAUSE_MERGE_SEC_FRAGMENT = _get_float("PAUSE_MERGE_SEC_FRAGMENT", "3.2")
+#PAUSE_MERGE_SEC_FRAGMENT = _get_float("PAUSE_MERGE_SEC_FRAGMENT", "3.2")
+PAUSE_MERGE_SEC_FRAGMENT = _get_float("PAUSE_MERGE_SEC_FRAGMENT", "6.0")
 FRAGMENT_MAX_BYTES = _get_int("FRAGMENT_MAX_BYTES", "16000")
 
 BARGE_IN_RMS = _get_float("BARGE_IN_RMS", "450.0")

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -77,7 +77,7 @@ VAD_DEBUG = _get_bool("VAD_DEBUG", "0")
 # Utterance merge / interruption control (server policy)
 # --------------------------------------------------
 #PAUSE_MERGE_SEC = _get_float("PAUSE_MERGE_SEC", "2.8")
-PAUSE_MERGE_SEC = _get_float("PAUSE_MERGE_SEC", "2.8")
+PAUSE_MERGE_SEC = _get_float("PAUSE_MERGE_SEC", "4.5")
 #PAUSE_MERGE_SEC_FRAGMENT = _get_float("PAUSE_MERGE_SEC_FRAGMENT", "3.2")
 PAUSE_MERGE_SEC_FRAGMENT = _get_float("PAUSE_MERGE_SEC_FRAGMENT", "6.0")
 FRAGMENT_MAX_BYTES = _get_int("FRAGMENT_MAX_BYTES", "16000")


### PR DESCRIPTION
## Goal
Keep SessionController tenant-agnostic by moving naan variant parsing + naan helpers into menu_knowledge.

## Changes
- SessionController now calls: extract_naan_variant_keyword_scoped / is_naan_item / naan_optima_prompt / find_naan_item_for_variant
- Removed dish-specific hinting (with_main=None)

## Tests
- python -m py_compile
- pytest -q (green)
